### PR TITLE
Fixed: Adding server URL to config file and disable autostart on success

### DIFF
--- a/recipes-extended/sudo/sudo_%.bbappend
+++ b/recipes-extended/sudo/sudo_%.bbappend
@@ -4,6 +4,9 @@ FILES_${PN} += "${sysconfdir}/sudoers"
 
 
 do_install_append() {
+    # Add exceptions to overwrite mender.conf and disable autostart.
     bbwarn "Appending \"user    ALL=(ALL:ALL) NOPASSWD:/bin/mv /tmp/mender.conf.tmp /etc/mender/mender.conf\" to /etc/sudoers"
     echo "user    ALL=(ALL:ALL) NOPASSWD:/bin/mv /tmp/mender.conf.tmp /etc/mender/mender.conf" >> ${D}${sysconfdir}/sudoers
+    bbwarn "Appending \"user    ALL=(ALL:ALL) NOPASSWD:/bin/mv /etc/xdg/autostart/mender-hostedlogin.desktop /etc/mender/login/mender-hostedlogin.desktop\" to /etc/sudoers"
+    echo "user    ALL=(ALL:ALL) NOPASSWD:/bin/mv /etc/xdg/autostart/mender-hostedlogin.desktop /etc/mender/login/mender-hostedlogin.desktop" >> ${D}${sysconfdir}/sudoers
 }

--- a/recipes-hosted-login/mender-hosted-login/mender-hostedlogin-0.1/menderLogin.py
+++ b/recipes-hosted-login/mender-hosted-login/mender-hostedlogin-0.1/menderLogin.py
@@ -183,6 +183,8 @@ class LogInWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
                 # Add TenantToken entry
                 data["TenantToken"] = r.json()["tenant_token"]
+                # Ensure that URL is set correctly
+                data["ServerURL"] = self.url_base
                 # Write temporary conf
                 f_tmp = open("/tmp/mender.conf.tmp", "w+")
                 # Rewrite mender.conf
@@ -202,9 +204,10 @@ class LogInWindow(QtWidgets.QMainWindow, Ui_MainWindow):
             # (Should not occur)
             os.makedirs("/etc/mender")
             try:
-                f = open("/etc/mender/mender.conf", "w+")
+                f = open("/tmp/mender.conf.tmp", "w")
                 # Create a new configuration holding the tenant token
-                data = {"TenantToken": r.json()["tenant_token"]}
+                data = {"TenantToken": r.json()["tenant_token"], \
+                        "ServerURL": self.url_base}
                 # Rewrite mender.conf
                 json.dump(data, f, indent=2)
             except:
@@ -218,6 +221,8 @@ class LogInWindow(QtWidgets.QMainWindow, Ui_MainWindow):
 
         # This is a bit hacky; maybe there's a better solution (TODO)
         os.system("sudo mv /tmp/mender.conf.tmp /etc/mender/mender.conf")
+        os.system("sudo mv /etc/xdg/autostart/mender-hostedlogin.desktop " + \
+                          "/etc/mender/login/mender-hostedlogin.desktop")
         # Token successfully written to /etc/mender.conf
         QtWidgets.QMessageBox.information(self, "Success",
                                           "Successfully stored your Hosted Mender token")


### PR DESCRIPTION
It now ensures that the config url is consistent with the url field in
the GUI, and disables autostart when token is fetched and stored.

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>